### PR TITLE
Don't duplicate the first API call.

### DIFF
--- a/src/views/components/search-box.jsx
+++ b/src/views/components/search-box.jsx
@@ -45,8 +45,9 @@ class SearchBox extends React.Component {
           this.setState({
             loadingFlag: true,
             offset: this.state.offset + 25,
+          }, () => {
+            this.fetchGifs();
           });
-          this.fetchGifs();
         }
       }
     }


### PR DESCRIPTION
This change changes the scrolling action by setting the `fetchGifs` function as a callback after setting the state of `offset`. It ensures we don't make a request to the API before the state has been set, resulting in duplicate calls for the first request.